### PR TITLE
18 так же добавил кнопку назад.Т.к на планшетах кнопки назад нет.

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -3,7 +3,20 @@
   <component name="deploymentTargetDropDown">
     <value>
       <entry key="app">
-        <State />
+        <State>
+          <runningDeviceTargetSelectedWithDropDown>
+            <Target>
+              <type value="RUNNING_DEVICE_TARGET" />
+              <deviceKey>
+                <Key>
+                  <type value="SERIAL_NUMBER" />
+                  <value value="dc26d6e1" />
+                </Key>
+              </deviceKey>
+            </Target>
+          </runningDeviceTargetSelectedWithDropDown>
+          <timeTargetWasSelectedWithDropDown value="2024-01-02T01:30:23.170850500Z" />
+        </State>
       </entry>
     </value>
   </component>

--- a/app/src/main/java/ru/stan/criminalintent/CrimeDetailFragment.kt
+++ b/app/src/main/java/ru/stan/criminalintent/CrimeDetailFragment.kt
@@ -185,6 +185,9 @@ class CrimeDetailFragment : Fragment() {
                 bundle.getSerializable(TimePickerFragment.BUNDLE_KEY_TIME) as Date
             crimeDetailViewModel.updateCrime { it.copy(date = newTime) }
         }
+        binding.backButton.setOnClickListener {
+            requireActivity().onBackPressed()
+        }
 
     }
 
@@ -223,7 +226,8 @@ class CrimeDetailFragment : Fragment() {
             if (crimeTitle.text.toString() != crime.title) {
                 crimeTitle.setText(crime.title)
             }
-            crimeDate.text = crime.date.toString()
+           // crimeDate.text = crime.date.toString()
+            crimeDate.text = localizeDate(crime.date)
             crimeDate.setOnClickListener {
                 findNavController().navigate(
                     CrimeDetailFragmentDirections.selectDate(crime.date)
@@ -333,7 +337,8 @@ class CrimeDetailFragment : Fragment() {
             getString(R.string.crime_report_unsolved)
         }
 
-        val dateString = DateFormat.format(DATE_FORMAT, crime.date).toString()
+       // val dateString = DateFormat.format(DATE_FORMAT, crime.date).toString()
+        val dateString = localizeDate(crime.date)
         val suspectText = if (crime.suspect.isBlank()) {
             getString(R.string.crime_report_no_suspect)
         } else {
@@ -360,6 +365,12 @@ class CrimeDetailFragment : Fragment() {
                 }
             }
         }
+    }
+    private fun localizeDate(date: Date): String {
+        val locale = Locale.CHINESE
+        val df = DateFormat.getBestDateTimePattern(locale, DATE_FORMAT)
+        val sdf = SimpleDateFormat(df, locale)
+        return sdf.format(date)
     }
 
     private fun canResolvelIntent(intent: Intent): Boolean {

--- a/app/src/main/res/layout/fragment_crime_detail.xml
+++ b/app/src/main/res/layout/fragment_crime_detail.xml
@@ -61,9 +61,8 @@
         android:text="@string/crime_solved_label" />
 
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="40dp"
-        android:layout_weight="0"
         android:orientation="horizontal">
 
         <Button
@@ -75,7 +74,7 @@
 
         <Button
             android:id="@+id/crime_time"
-            android:layout_width="130dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             tools:text="11:56 EST" />
@@ -100,5 +99,11 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/call"/>
+
+    <Button
+        android:id="@+id/backButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/backButton" />
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,4 +26,5 @@
     <string name="send_report">Send crime report via</string>
     <string name="call">Call</string>
     <string name="photo">photo</string>
+    <string name="backButton">Назад</string>
 </resources>


### PR DESCRIPTION
Localization Challenge: Localizing Dates
             You may have noticed that, regardless of the device’s locale, the dates displayed in CriminalIntent are always formatted in the default US style, with the month before the day. Take your localization a step further by formatting the dates according to the locale configuration. It is easier than you might think.
             Check out the developer documentation on the DateFormat class, which is provided as part of the Android framework. DateFormat provides a date-time formatter that will take into consideration the current locale. You can control the output further by using configuration constants built into DateFormat.